### PR TITLE
Proxy addresses login

### DIFF
--- a/classes/Adi/Authentication/LoginService.php
+++ b/classes/Adi/Authentication/LoginService.php
@@ -138,13 +138,11 @@ class NextADInt_Adi_Authentication_LoginService
 		// https://wordpress.org/support/topic/fatal-error-after-login-and-suffix-question/
 		$login = stripcslashes($login);
 
-		$this->logger->debug("The login: " . $login);
+		// EJN - 2017/11/16 - Allow users to log in with one of their email addresses specified in proxyAddresses
 		// Check if this looks like a ProxyAddress and look up sAMAccountName if we are allowing ProxyAddresses as login.
 		$allowProxyAddressLogin = $this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::ALLOW_PROXYADDRESS_LOGIN);
 		if($allowProxyAddressLogin && strpos($login, '@') !== false) {
-			$this->logger->debug("Checking if this is a proxy address.");
 			$login = $this->lookupFromProxyAddresses($login);
-			$this->logger->debug("After looking up sAMAccountName: " . $login);
 		}
 		
 		// login must not be empty or user must not be an admin
@@ -187,13 +185,15 @@ class NextADInt_Adi_Authentication_LoginService
 	/**
 	 * Lookup the user's sAMAccountName by their SMTP proxy addresses. If not found, just return the proxy address.
 	 *
+	 * EJN - 2017/11/16 - Allow users to log in with one of their email addresses specified in proxyAddresses
+	 *
 	 * @param String $proxyAddress The proxy address to try looking up.
 	 *
 	 * @return The associated sAMAccountName or $proxyAddress if not found.
 	 */
 	public function lookupFromProxyAddresses($proxyAddress) {
 		
-		// Use the Sync username and password since anonymous bind can't search.
+		// Use the Sync to WordpPress username and password since anonymous bind can't search.
 		$connectionDetails = new NextADInt_Ldap_ConnectionDetails();
 		$connectionDetails->setUsername($this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::SYNC_TO_WORDPRESS_USER));
 		$connectionDetails->setPassword($this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::SYNC_TO_WORDPRESS_PASSWORD));
@@ -207,11 +207,13 @@ class NextADInt_Adi_Authentication_LoginService
 		if($domainControllerIsAvailable) {
 			$samaccountname = $this->ldapConnection->findByProxyAddress($proxyAddress);
 		
+			// If this email address wasn't specified in anyone's proxyAddresses attributes, just return the original value.
 			if($samaccountname === false) {
 				return $proxyAddress;
 			}
 		}
 		
+		// Return the account we looked up.
 		return $samaccountname;		
 	}
 

--- a/classes/Adi/Authentication/LoginService.php
+++ b/classes/Adi/Authentication/LoginService.php
@@ -138,6 +138,15 @@ class NextADInt_Adi_Authentication_LoginService
 		// https://wordpress.org/support/topic/fatal-error-after-login-and-suffix-question/
 		$login = stripcslashes($login);
 
+		$this->logger->debug("The login: " . $login);
+		// Check if this looks like a ProxyAddress and look up sAMAccountName if we are allowing ProxyAddresses as login.
+		$allowProxyAddressLogin = $this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::ALLOW_PROXYADDRESS_LOGIN);
+		if($allowProxyAddressLogin && strpos($login, '@') !== false) {
+			$this->logger->debug("Checking if this is a proxy address.");
+			$login = $this->lookupFromProxyAddresses($login);
+			$this->logger->debug("After looking up sAMAccountName: " . $login);
+		}
+		
 		// login must not be empty or user must not be an admin
 		if (!$this->requiresActiveDirectoryAuthentication($login)) {
 			return false;
@@ -173,6 +182,37 @@ class NextADInt_Adi_Authentication_LoginService
 			$this->logger->warn("XML-RPC Login detected ! Preventing further authentication.");
 			wp_die(__("Next ADI prevents XML RPC authentication!", 'next-active-directory-integration'));
 		}
+	}
+	
+	/**
+	 * Lookup the user's sAMAccountName by their SMTP proxy addresses. If not found, just return the proxy address.
+	 *
+	 * @param String $proxyAddress The proxy address to try looking up.
+	 *
+	 * @return The associated sAMAccountName or $proxyAddress if not found.
+	 */
+	public function lookupFromProxyAddresses($proxyAddress) {
+		
+		// Use the Sync username and password since anonymous bind can't search.
+		$connectionDetails = new NextADInt_Ldap_ConnectionDetails();
+		$connectionDetails->setUsername($this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::SYNC_TO_WORDPRESS_USER));
+		$connectionDetails->setPassword($this->configuration->getOptionValue(NextADInt_Adi_Configuration_Options::SYNC_TO_WORDPRESS_PASSWORD));
+		
+		// LDAP_Connection
+		$this->ldapConnection->connect($connectionDetails);
+
+		// check if domain controller is available
+		$domainControllerIsAvailable = $this->ldapConnection->checkPorts();
+		
+		if($domainControllerIsAvailable) {
+			$samaccountname = $this->ldapConnection->findByProxyAddress($proxyAddress);
+		
+			if($samaccountname === false) {
+				return $proxyAddress;
+			}
+		}
+		
+		return $samaccountname;		
 	}
 
 	/**
@@ -225,7 +265,7 @@ class NextADInt_Adi_Authentication_LoginService
 	{
 		return new NextADInt_Adi_Authentication_Credentials($login, $password);
 	}
-
+	
 	/**
 	 * Check if the Active Directory authentication is required or not.
 	 * If the username is empty or the user is WordPress first/admin account, an Active Directory authentication will *not* be executed.

--- a/classes/Adi/Configuration/Options.php
+++ b/classes/Adi/Configuration/Options.php
@@ -38,6 +38,7 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
 	// User - User Settings
 	const EXCLUDE_USERNAMES_FROM_AUTHENTICATION = 'exclude_usernames_from_authentication';
 	const ACCOUNT_SUFFIX = 'account_suffix';
+	const ALLOW_PROXYADDRESS_LOGIN = 'allow_proxyaddress_login';
 	const USE_SAMACCOUNTNAME_FOR_NEW_USERS = 'use_samaccountname_for_new_users';
 	const AUTO_CREATE_USER = 'auto_create_user';
 	const AUTO_UPDATE_USER = 'auto_update_user';
@@ -548,6 +549,24 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
                 $angularButtonAttributes => 'ng-show="!$parent.is_input_empty(new_account_suffix)"',
 				$default     => '',
 				$sanitizer   => array('accumulation', ';', array('string', false, true)),
+				$showPermission    => true,
+				$transient         => false,
+			),
+			// Should the user be able to use one of their ProxyAddresses instead of their sAMAccountName for login? Their sAMAccountName will be looked up from the ProxyAddress.
+			self::ALLOW_PROXYADDRESS_LOGIN => array(
+				$title       => __('Allow users to login with one of their ProxyAddresses', 'next-active-directory-integration'),
+				$type        => NextADInt_Multisite_Option_Type::CHECKBOX,
+				$description => __(
+					'If checked, users will be able to use one of their ProxyAddreses instead of their sAMAccountName to login.',
+					'next-active-directory-integration'
+				),
+				$detail      => __(
+					'Instead of using the user principal name for newly created users, the sAMAccountName will be used. The ProxyAddress will be used to lookup the sAMAccountName.',
+					'next-active-directory-integration'
+				),
+				$angularAttributes => '',
+				$default     => false,
+				$sanitizer   => array('boolean'),
 				$showPermission    => true,
 				$transient         => false,
 			),

--- a/classes/Adi/Configuration/Ui/Layout.php
+++ b/classes/Adi/Configuration/Ui/Layout.php
@@ -124,6 +124,7 @@ class NextADInt_Adi_Configuration_Ui_Layout
 					self::OPTIONS => array(
 						NextADInt_Adi_Configuration_Options::EXCLUDE_USERNAMES_FROM_AUTHENTICATION,
 						NextADInt_Adi_Configuration_Options::ACCOUNT_SUFFIX,
+						NextADInt_Adi_Configuration_Options::ALLOW_PROXYADDRESS_LOGIN,
 						NextADInt_Adi_Configuration_Options::USE_SAMACCOUNTNAME_FOR_NEW_USERS,
 						NextADInt_Adi_Configuration_Options::AUTO_CREATE_USER,
 						NextADInt_Adi_Configuration_Options::AUTO_UPDATE_USER,

--- a/classes/Ldap/Connection.php
+++ b/classes/Ldap/Connection.php
@@ -35,7 +35,8 @@ class NextADInt_Ldap_Connection
 	 */
 	public function __construct(NextADInt_Multisite_Configuration_Service $configuration)
 	{
-		if (!class_exists('adLDAP')) {
+		// Use our extended version of the adLDAP library.
+		if (!class_exists('NextADInt_adLDAP')) {
 			// get NextAdInt_adLdap
 			require_once '_adLDAP.php';
 		}

--- a/classes/Ldap/Connection.php
+++ b/classes/Ldap/Connection.php
@@ -36,10 +36,10 @@ class NextADInt_Ldap_Connection
 	public function __construct(NextADInt_Multisite_Configuration_Service $configuration)
 	{
 		if (!class_exists('adLDAP')) {
-			// get adLdap
-			require_once NEXT_AD_INT_PATH . '/vendor/adLDAP/adLDAP.php';
+			// get NextAdInt_adLdap
+			require_once '_adLDAP.php';
 		}
-
+		
 		$this->configuration = $configuration;
 
 		$this->logger = NextADInt_Core_Logger::getLogger();
@@ -242,7 +242,7 @@ class NextADInt_Ldap_Connection
 	 */
 	function createAdLdap($config)
 	{
-		$this->adldap = new adLDAP($config);
+		$this->adldap = new NextADInt_adLDAP($config);
 	}
 
 	/**
@@ -263,6 +263,18 @@ class NextADInt_Ldap_Connection
 	public function isConnected()
 	{
 		return is_object($this->adldap);
+	}
+	
+	/**
+	 *  Find the sAMAccountName associated with a ProxyAddress
+	 *  
+	 *  @param string $proxyAddress The proxy address to check
+	 *  
+	 *  @return false if not found or the sAMAccountName.
+	 */
+	public function findByProxyAddress($proxyAddress)
+	{
+		return $this->adldap->findByProxyAddress($proxyAddress);
 	}
 
 	/**

--- a/classes/Ldap/_adLDAP.php
+++ b/classes/Ldap/_adLDAP.php
@@ -1,0 +1,39 @@
+<?php
+if (!defined('ABSPATH')) {
+	die('Access denied.');
+}
+
+if (class_exists('NextADInt_adLdap')) {
+	return;
+}
+
+if (!class_exists('adLDAP')) {
+	// get adLdap
+	require_once NEXT_AD_INT_PATH . '/vendor/adLDAP/adLDAP.php';
+}
+
+/**
+ * This class extends the functionality of the adLDAP library. 
+ *
+ * NextADInt_adLdap allows additional functions needed by NADI that are not covered by adLDAP without needing to manage the LDAP configuration.
+ *
+ * @author Erik Nedwidek
+ * @access public
+ */
+class NextADInt_adLDAP extends adLDAP {
+	
+	public function findByProxyAddress($proxyAddress) 
+	{
+		$filter="(&(objectCategory=user)(proxyAddresses~=smtp:" . $proxyAddress . "))";
+        $fields = array("samaccountname");
+        $sr=ldap_search($this->_conn,$this->_base_dn,$filter,$fields);
+        $entries = ldap_get_entries($this->_conn, $sr);
+		
+		if($entries['count'] == 0 || $entries['count'] > 1) {
+			$logger->debug("Number of entries: " . $entries['count']);
+			return false;
+		}
+		
+		return $entries[0]['samaccountname'][0];
+	}
+}

--- a/classes/Ldap/_adLDAP.php
+++ b/classes/Ldap/_adLDAP.php
@@ -22,6 +22,15 @@ if (!class_exists('adLDAP')) {
  */
 class NextADInt_adLDAP extends adLDAP {
 	
+	/**
+	 *  Finds the sAMAccountName for the LDAP record that has the given email address in one of its proxyAddresses attributes.
+	 *  
+	 *  EJN - 2017/11/16 - Allow users to log in with one of their email addresses specified in proxyAddresses
+	 *  
+	 * @param String $proxyAddress The proxy address to use in the look up.
+	 *
+	 * @return The associated sAMAccountName or false if not found or uniquely found.
+	 */
 	public function findByProxyAddress($proxyAddress) 
 	{
 		$filter="(&(objectCategory=user)(proxyAddresses~=smtp:" . $proxyAddress . "))";
@@ -29,6 +38,7 @@ class NextADInt_adLDAP extends adLDAP {
         $sr=ldap_search($this->_conn,$this->_base_dn,$filter,$fields);
         $entries = ldap_get_entries($this->_conn, $sr);
 		
+		// Return false if we didn't find exactly one entry.
 		if($entries['count'] == 0 || $entries['count'] > 1) {
 			$logger->debug("Number of entries: " . $entries['count']);
 			return false;

--- a/js/app/blog-options/controllers/user.controller.js
+++ b/js/app/blog-options/controllers/user.controller.js
@@ -35,6 +35,7 @@
             $scope.option = {
                 account_suffix: $valueHelper.findValue("account_suffix", data, "").split(";"),
                 exclude_usernames_from_authentication: $valueHelper.findValue("exclude_usernames_from_authentication", data, "").split(";"),
+				allow_proxyaddress_login: $valueHelper.findValue("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findValue("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findValue("auto_create_user", data),
                 auto_update_user: $valueHelper.findValue("auto_update_user", data),
@@ -53,6 +54,7 @@
             $scope.permission = {
                 account_suffix: $valueHelper.findPermission("account_suffix", data),
                 exclude_usernames_from_authentication: $valueHelper.findPermission("exclude_usernames_from_authentication", data),
+				allow_proxyaddress_login: $valueHelper.findPermission("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findPermission("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findPermission("auto_create_user", data),
                 auto_update_user: $valueHelper.findPermission("auto_update_user", data),
@@ -73,6 +75,7 @@
             $scope.messages = {
                 account_suffix: $valueHelper.findMessage("account_suffix", data),
                 exclude_usernames_from_authentication: $valueHelper.findMessage("exclude_usernames_from_authentication", data),
+				allow_proxyaddress_login: $valueHelper.findMessage("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findMessage("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findMessage("auto_create_user", data),
                 auto_update_user: $valueHelper.findMessage("auto_update_user", data),

--- a/js/app/profile-options/controllers/user.controller.js
+++ b/js/app/profile-options/controllers/user.controller.js
@@ -37,6 +37,7 @@
             $scope.option = {
                 account_suffix: $valueHelper.findValue("account_suffix", data, "").split(";"),
                 exclude_usernames_from_authentication: $valueHelper.findValue("exclude_usernames_from_authentication", data, "").split(";"),
+				allow_proxyaddress_login: $valueHelper.findValue("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findValue("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findValue("auto_create_user", data),
                 auto_update_user: $valueHelper.findValue("auto_update_user", data),
@@ -57,6 +58,7 @@
             $scope.permission = {
                 account_suffix: $valueHelper.findPermission("account_suffix", data),
                 exclude_usernames_from_authentication: $valueHelper.findPermission("exclude_usernames_from_authentication", data),
+				allow_proxyaddress_login: $valueHelper.findPermission("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findPermission("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findPermission("auto_create_user", data),
                 auto_update_user: $valueHelper.findPermission("auto_update_user", data),
@@ -73,6 +75,7 @@
             $scope.messages = {
                 account_suffix: $valueHelper.findMessage("account_suffix", data),
                 exclude_usernames_from_authentication: $valueHelper.findMessage("exclude_usernames_from_authentication", data),
+				allow_proxyaddress_login: $valueHelper.findMessage("allow_proxyaddress_login", data),
                 use_samaccountname_for_new_users: $valueHelper.findMessage("use_samaccountname_for_new_users", data),
                 auto_create_user: $valueHelper.findMessage("auto_create_user", data),
                 auto_update_user: $valueHelper.findMessage("auto_update_user", data),


### PR DESCRIPTION
Allows login with one of the email addresses in the user's proxyAddresses attributes. Pre-login bind is handled using the user ID and password specified by SYNC_TO WORDPRESS_USER and SYNC_TO_WORDPRESS_PASSWORD.

My users are often confused by whether to use their email address or Windows domain ID. This will simplify things by allowing them to use either. 

This feature is enabled/disabled on the User tab and uses the user ID and password on the Sync to Wordpress tab for the pre-authentication LDAP search.

