### PR TITLE
Submit email on user creation for compatibility with other plugins

### DIFF
--- a/classes/Adi/User/Manager.php
+++ b/classes/Adi/User/Manager.php
@@ -219,7 +219,7 @@ class NextADInt_Adi_User_Manager
 			$this->checkDuplicateEmail($wpUserLogin, $email);
 
 			// create a new user and assign the id to the user object
-			$userId = $this->userRepository->create($user);
+			$userId = $this->userRepository->create($user, $email);
 			NextADInt_Core_Util_ExceptionUtil::handleWordPressErrorAsException($userId);
 			$user->setId($userId);
 

--- a/classes/Adi/User/Persistence/Repository.php
+++ b/classes/Adi/User/Persistence/Repository.php
@@ -234,9 +234,9 @@ class NextADInt_Adi_User_Persistence_Repository
 	 *
 	 * @throws NextADInt_Core_Exception_WordPressErrorException
 	 */
-	public function create(NextADInt_Adi_User $user)
+	public function create(NextADInt_Adi_User $user, $email)
 	{
-		$result = wp_create_user($user->getUserLogin(), $user->getCredentials()->getPassword());
+		$result = wp_create_user($user->getUserLogin(), $user->getCredentials()->getPassword(), $email);
 
 		if (is_wp_error($result)) {
 			// log error


### PR DESCRIPTION
Plugins using [`user_register` hook](https://codex.wordpress.org/Plugin_API/Action_Reference/user_register) fail when relying on a mandatory e-mail address (like [Email posts to subscribers](http://www.gopiplus.com/work/2014/03/28/wordpress-plugin-email-posts-to-subscribers/)). These changes submit the LDAP-Users mail address to [`wp_create_user`](https://codex.wordpress.org/Function_Reference/wp_create_user) so it becomes available to users of the hook.