### PR TITLE
Always load auth hook callback if the user is not logged in

### DIFF
--- a/classes/Adi/Init.php
+++ b/classes/Adi/Init.php
@@ -188,16 +188,11 @@ class NextADInt_Adi_Init
 			$this->registerSsoHooks();
 		}
 
-		if ($this->isOnLoginPage()) {
-			$this->registerLoginHooks();
-
-			// further hooks must not be executed
-			return false;
-		}
-
 		$currentUserId = wp_get_current_user()->ID;
 
 		if (!$currentUserId) {
+			$this->registerLoginHooks();
+			
 			// the current user is not logged in so further hooks must not be processed
 			return false;
 		}


### PR DESCRIPTION
Changed logic to load the authentication filter callback any time the user is not logged in rather than only on wp-login.php and xmlrpc.php pages. Some plugins provide their own login pages and NADI wouldn't handle the call for the authentication filter since the url did not contain wp-login.php or xmlrpc.php.

As an example: We are using Awesome Support for our ticketing system. Awesome support shows a login form on the list of tickets page. The same form is shown if the user follows a link in the email sent to them when the ticket is updated.

They would get an invalid user id or password error. Other site admins have reported the same issue in Awesome Support forums. With the proposed change, my users are no longer having login issues.