### PR TITLE
Fix deprecated curly brace array access

### DIFF
--- a/vendor/adLDAP/adLDAP.php
+++ b/vendor/adLDAP/adLDAP.php
@@ -2692,7 +2692,7 @@ class adLDAP {
     protected function encode_password($password){
         $password="\"".$password."\"";
         $encoded="";
-        for ($i=0; $i <strlen($password); $i++){ $encoded.="{$password{$i}}\000"; }
+        for ($i=0; $i <strlen($password); $i++){ $encoded.="{$password[$i]}\000"; }
         return ($encoded);
     }
     


### PR DESCRIPTION
Curly brace array access has been deprecated in PHP 7.4, https://wiki.php.net/rfc/deprecate_curly_braces_array_access.

I did a quick search and did not find any other cases.

