### PR TITLE
Add array of custom login form URIs

### DIFF
--- a/classes/Adi/Init.php
+++ b/classes/Adi/Init.php
@@ -319,7 +319,11 @@ class NextADInt_Adi_Init
             }
 		}
 
-		if ($isOnLoginPage) {
+		// array of custom login form URIs should be created in NADI settings
+		if ($isOnLoginPage || in_array(strtok($_SERVER["REQUEST_URI"],'?'), array (
+			"/wp-json/jwt-auth/v1/token" ,
+			"/wp-json/jwt-auth/v1/token/validate",
+			))) {
 		    do_action(NEXT_AD_INT_PREFIX . 'register_form_login_services');
 
 			// further hooks must not be executed


### PR DESCRIPTION
Adding wp-api-jwt-auth support.
Although this plugin is the recommended by Wordpress this could be a bit specific, so maybe the best idea is to fill that array of URIs on NADI settings as alternatives custom forms.