### PR TITLE
Add custom login page URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,10 @@ will be automatically tested.
 
 ### Release process
 Every pushed tag will be automatically tested. After a succesful test, it gets uploaded to wordpress.org.
+
+To create a new release:
+
+```bash
+git tag -a ${VERSION} -m "release of ${VERSION}"
+git push origin ${VERSION}
+```

--- a/classes/Adi/Configuration/Options.php
+++ b/classes/Adi/Configuration/Options.php
@@ -108,6 +108,7 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
 
 	// Custom Login Page
 	const CUSTOM_LOGIN_PAGE_ENABLED = 'custom_login_page_enabled';
+	const CUSTOM_LOGIN_PAGE_URI = 'custom_login_page_uri';
 
 	// additional attribute mapping
 	const ATTRIBUTES_COLUMN_TYPE = "type";
@@ -1164,6 +1165,18 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
 				$detail => __('Enables authentication against the Active Directory on a custom login page.', 'next-active-directory-integration'),
 				$default => false,
 				$sanitizer => array('boolean'),
+				$showPermission => true,
+				$transient => false,
+			),
+			self::CUSTOM_LOGIN_PAGE_URI => array(
+				$title => __('Custom login page URI', 'next-active-directory-integration'),
+				$type => NextADInt_Multisite_Option_Type::TEXT,
+				$description => __('URI of the login page where authentication against the Active Directory will be enabled. It should start with slash, eg. "/login".',
+					'next-active-directory-integration'),
+				$detail => __('If you use custom login page URI like "/login" please enter it to enable Active Directory authentication check on this page.', 'next-active-directory-integration'),
+				$angularAttributes => 'ng-disabled="(!option.custom_login_page_enabled',
+				$default => '/login',
+				$sanitizer => array('string'),
 				$showPermission => true,
 				$transient => false,
 			),

--- a/classes/Adi/Configuration/Options.php
+++ b/classes/Adi/Configuration/Options.php
@@ -190,8 +190,8 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
 	}
 
 	/**
-	 * This method generates all the meta information for a option elements.
-	 * The keys (like self::DOMAIN_CONTROLLERS, self::PORT) and it is values are option elements.
+	 * This method generates all the meta information for an option elements.
+	 * The keys (like self::DOMAIN_CONTROLLERS, self::PORT) and their values are option elements.
 	 * The key is the internal name for the option and the value is the option meta data.
 	 *
 	 * The option meta data contains information like:
@@ -1171,9 +1171,9 @@ class NextADInt_Adi_Configuration_Options implements NextADInt_Multisite_Option_
 			self::CUSTOM_LOGIN_PAGE_URI => array(
 				$title => __('Custom login page URI', 'next-active-directory-integration'),
 				$type => NextADInt_Multisite_Option_Type::TEXT,
-				$description => __('URI of the login page where authentication against the Active Directory will be enabled. It should start with slash, eg. "/login".',
+				$description => __('URI of a custom login page where authentication against the Active Directory will be enabled. By default, the custom login page\'s URI is <em>/login</em>.',
 					'next-active-directory-integration'),
-				$detail => __('If you use custom login page URI like "/login" please enter it to enable Active Directory authentication check on this page.', 'next-active-directory-integration'),
+				$detail => __('If you use a custom login page URI like <em>/login</em>, please enter it to enable Active Directory authentication check on this page.', 'next-active-directory-integration'),
 				$angularAttributes => 'ng-disabled="(!option.custom_login_page_enabled',
 				$default => '/login',
 				$sanitizer => array('string'),

--- a/classes/Adi/Configuration/Ui/Layout.php
+++ b/classes/Adi/Configuration/Ui/Layout.php
@@ -234,7 +234,8 @@ class NextADInt_Adi_Configuration_Ui_Layout
 					// Option elements in group
 					self::OPTIONS => array(
 						NextADInt_Adi_Configuration_Options::ENABLE_SMARTCARD_USER_LOGIN,
-						NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_ENABLED
+						NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_ENABLED,
+						NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_URI
 					),
 				),
 				// Group name

--- a/classes/Adi/Init.php
+++ b/classes/Adi/Init.php
@@ -486,6 +486,7 @@ class NextADInt_Adi_Init
 
 		if ($customLoginPageEnabled) {
 			$loginUri = $this->dc()->getConfiguration()->getOptionValue(NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_URI);
+
 			if (isset($_SERVER["REQUEST_URI"]) && strpos($_SERVER["REQUEST_URI"], $loginUri) !== false) {
 				$r = true;
 			}

--- a/classes/Adi/Init.php
+++ b/classes/Adi/Init.php
@@ -485,7 +485,8 @@ class NextADInt_Adi_Init
 		$customLoginPageEnabled = $this->dc()->getConfiguration()->getOptionValue(NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_ENABLED);
 
 		if ($customLoginPageEnabled) {
-			if (isset($_SERVER["REQUEST_URI"]) && strpos($_SERVER["REQUEST_URI"], '/login') !== false) {
+			$loginUri = $this->dc()->getConfiguration()->getOptionValue(NextADInt_Adi_Configuration_Options::CUSTOM_LOGIN_PAGE_URI);
+			if (isset($_SERVER["REQUEST_URI"]) && strpos($_SERVER["REQUEST_URI"], $loginUri) !== false) {
 				$r = true;
 			}
 		}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     },
     "require": {
         "twig/twig": "3.3.*",
+        "symfony/polyfill-mbstring": "1.20",
         "defuse/php-encryption": "2.0.3",
         "monolog/monolog": "^1.0"
     }

--- a/js/app/blog-options/controllers/security.controller.js
+++ b/js/app/blog-options/controllers/security.controller.js
@@ -25,6 +25,7 @@
             $scope.option = {
                 enable_smartcard_user_login: $valueHelper.findValue("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findValue("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findValue("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findValue("max_login_attempts", data),
                 block_time: $valueHelper.findValue("block_time", data),
                 user_notification: $valueHelper.findValue("user_notification", data),
@@ -41,6 +42,7 @@
             $scope.permission = {
                 enable_smartcard_user_login: $valueHelper.findPermission("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findPermission("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findPermission("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findPermission("max_login_attempts", data),
                 block_time: $valueHelper.findPermission("block_time", data),
                 user_notification: $valueHelper.findPermission("user_notification", data),
@@ -55,6 +57,7 @@
             $scope.messages = {
                 enable_smartcard_user_login: $valueHelper.findMessage("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findMessage("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findMessage("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findMessage("max_login_attempts", data),
                 block_time: $valueHelper.findMessage("block_time", data),
                 user_notification: $valueHelper.findMessage("user_notification", data),

--- a/js/app/profile-options/controllers/security.controller.js
+++ b/js/app/profile-options/controllers/security.controller.js
@@ -27,6 +27,7 @@
             $scope.option = {
                 enable_smartcard_user_login: $valueHelper.findValue("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findValue("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findValue("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findValue("max_login_attempts", data),
                 block_time: $valueHelper.findValue("block_time", data),
                 user_notification: $valueHelper.findValue("user_notification", data),
@@ -45,6 +46,7 @@
             $scope.permission = {
                 enable_smartcard_user_login: $valueHelper.findPermission("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findPermission("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findPermission("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findPermission("max_login_attempts", data),
                 block_time: $valueHelper.findPermission("block_time", data),
                 user_notification: $valueHelper.findPermission("user_notification", data),
@@ -59,6 +61,7 @@
             $scope.messages = {
                 enable_smartcard_user_login: $valueHelper.findMessage("enable_smartcard_user_login", data),
                 custom_login_page_enabled: $valueHelper.findMessage("custom_login_page_enabled", data),
+                custom_login_page_uri: $valueHelper.findMessage("custom_login_page_uri", data),
                 max_login_attempts: $valueHelper.findMessage("max_login_attempts", data),
                 block_time: $valueHelper.findMessage("block_time", data),
                 user_notification: $valueHelper.findMessage("user_notification", data),

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For detailed information you can visit the official [GitHub repository of Next A
 * FIXED: Critical WordPress error if a matching profile for SSO authentication can not be found (gh-#152, NADISUP-7)
 * FIXED: Uncaught TypeError when checking userAccountControl attribute (gh-#151)
 * FIXED: For specific Active Directory forest structures, the NETBIOS name can not be resolved during verification of the credentials (gh-#153, NADISUP-8)
+* ADDED: Option for specifying a custom login page URI; special thanks to GitHub user *czoIg* for contributing this functionality (gh-#154)
 
 = 2.3.1 =
 * CHANGED: WordPress 5.9 compatibility has been checked


### PR DESCRIPTION
If site is using plugin to change login page uri to custom text, AD integration is not working, because it only checks `/login` in case of custom login page option enabled.

This PR adds ability to configure this custom URI.